### PR TITLE
Add Resize capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pillow
 ips.py
+rembg


### PR DESCRIPTION
Modifies the script adding the capability of resize the input image to 308*350 preserving Aspect Ratio.

In order to resize the image, first the background is removed, the resultant image is cropped to the minimum, then resized preserving aspect ratio to 308*350 and the background is replaced it by a black one.

Two new arguments are added:

"-nr", "--no_remove" if is yes, the background is not removed, so the image is resized as is

"-sp", "--Save_Processed", if set, a copy of the processed image is saved with that name/path.

Its a Quick and Dirty implementation but works fine.